### PR TITLE
Create UQTR-histoire.csl

### DIFF
--- a/UQTR-histoire.csl
+++ b/UQTR-histoire.csl
@@ -1,0 +1,753 @@
+
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" default-locale="fr-CA">
+  <info>
+    <title>Université du Québec à Trois-Rivières - Département des sciences humaines (Français - Canada)</title>
+    <title-short>UQTR-histoire</title-short>
+    <id>http://www.zotero.org/styles/uqtr-departement-des-sciences-humaines</id>
+    <link href="http://www.zotero.org/styles/uqtr-departement-des-sciences-humaines" rel="self"/>
+    <link href="https://oraprdnt.uqtr.uquebec.ca/pls/public/docs/FWG/GSC/Publication/5143/47/12868/1/491327/5/O0004473103_Guide_corrig_.pdf" rel="documentation"/>
+    <author>
+      <name>Gabriel Ferland</name>
+      <email>gabriel.ferland@uqtr.ca</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="history"/>
+    <updated>2023-07-24T20:28:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="ordinal-01">ère</term>
+      <term name="ordinal-02">e</term>
+      <term name="ordinal-03">e</term>
+      <term name="ordinal-04">e</term>
+      <term name="cited">op. cit.</term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+          </name>
+          <label form="short" prefix=", "/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-opcit">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name initialize-with="." and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+            <name-part name="family"/>
+          </name>
+          <label form="short" prefix=", " suffix="."/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-bib">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="first" form="long" and="text" delimiter-precedes-last="never" sort-separator=", " font-style="normal">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="uppercase" suffix=","/>
+          </name>
+          <label form="short" prefix=", "/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <text value="trad. par "/>
+    <names variable="translator">
+      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="man-archive">
+    <choose>
+      <if type="manuscript" match="any">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="call-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="document">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song article-journal article-magazine chapter entry-dictionary entry-encyclopedia webpage" match="none">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <text variable="call-number"/>
+          <text variable="title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title-cit">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine paper-conference" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="title" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+          <text value="dans" font-style="normal" suffix=" " prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <group>
+          <text variable="title" text-case="capitalize-first" quotes="true" suffix=","/>
+          <text variable="genre" text-case="lowercase" prefix=" "/>
+          <text variable="publisher" prefix=", "/>
+        </group>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <group delimiter=",">
+          <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <group suffix=", dans ">
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
+        </group>
+        <group>
+           <names variable="container-author" suffix=", dir.,">
+	    <name form="long" and="text" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+           </name>
+          <et-al font-style="italic"/>
+          </names>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix=" " suffix=", "/>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+          <text variable="container-title" font-style="italic" text-case="capitalize-first" suffix=" "/>
+        </group>
+          <date variable="issued">
+            <date-part name="day" prefix="(" suffix=" "/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" suffix="), "/>
+          </date>
+          <group delimiter=" ">
+            <text variable="URL"/>
+            <date form="text" variable="accessed" prefix="(Page consultée le " suffix=")"/>
+          </group>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+      </if>
+      <else-if type="article-journal article-magazine paper-conference" match="any">
+        <group delimiter=". " suffix=", ">
+          <text variable="title" text-case="title" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper" match="any">
+        <group delimiter=". ">
+          <text variable="title" text-case="title" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+          <text value="dans" font-style="normal" suffix=" " prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <group>
+          <text variable="title" text-case="capitalize-first" quotes="true" suffix="."/>
+          <text variable="genre" prefix=" "/>
+          <text variable="publisher" prefix=", "/>
+        </group>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <group delimiter=",">
+          <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <group suffix=". ">
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
+        </group>
+        <group>
+           <names variable="container-author" suffix=", dir.">
+	    <name form="long" and="text" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+           </name>
+          <et-al font-style="italic"/>
+          </names>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog" match="any">
+          <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal" suffix=". "/>
+          <text variable="container-title" font-style="italic" text-case="capitalize-first" suffix=" "/>
+          <date variable="issued">
+            <date-part name="day" suffix=" " prefix="("/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" suffix="). "/>
+          </date>
+          <group delimiter=" ">
+            <text variable="URL"/>
+            <date form="text" variable="accessed" prefix="(Page consultée le " suffix=")"/>
+          </group>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pub-place">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation manuscript motion_picture paper-conference report song thesis" match="any">
+        <text variable="publisher-place"/>
+      </if>
+      <else-if type="article-newspaper" match="any">
+        <text variable="publisher-place" prefix=" (" suffix=")"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song article-magazine" match="any">
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="yearpage">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis" match="any">
+        <group delimiter=", " font-style="normal">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <group>
+            <text term="volume" form="short" suffix="."/>
+            <text variable="number-of-volumes" prefix=". " suffix="/"/>
+            <text variable="volume"/>
+          </group>
+          <choose>
+            <if variable="locator" match="any">
+              <text variable="locator" prefix="p. "/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia article-magazine" match="any">
+        <group delimiter=" " font-style="normal">
+          <date variable="issued">
+            <date-part name="year" suffix=", "/>
+          </date>
+          <group>
+            <text term="volume" form="short" suffix="."/>
+            <text variable="volume" suffix=","/>
+          </group>
+          <choose>
+            <if variable="locator" match="any">
+              <text variable="locator" prefix="p. "/>
+            </if>
+            <else-if variable="locator" match="none">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </else-if>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="article-magazine" match="any">
+        <group delimiter=" " font-style="normal">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+        <group delimiter=" " font-style="normal">
+          <choose>
+            <if variable="locator" match="any">
+              <text variable="locator" prefix="p. "/>
+            </if>
+            <else-if variable="locator" match="none">
+              <label variable="page" form="short"/>
+            </else-if>
+          </choose>
+        </group>
+      </else-if>
+      <else>
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year" suffix=""/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="yearpage-bib">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis chapter entry-dictionary entry-encyclopedia" match="any">
+        <group font-style="normal">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if type="article-newspaper" match="any">
+        <group font-style="normal" prefix=", ">
+          <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year" suffix=""/>
+          </date>
+        </group>
+        <group delimiter=", " font-style="normal">
+          <number variable="number-of-pages"/>
+          <text variable="page" prefix=" : "/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="nbr-page">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture report song thesis entry-dictionary article-journal" match="any">
+        <group delimiter=", " font-style="normal">
+          <number variable="number-of-pages" suffix="p."/>
+          <text variable="page" prefix=" "/>
+        </group>
+      </if>
+      <else-if type="article-newspaper" match="any">
+        <group font-style="normal">
+          <text variable="page" prefix=", p. "/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="chapter-nbr-page">
+    <choose>
+      <if type="chapter" match="any">
+        <group font-style="normal">
+          <text variable="page" suffix="p."/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="conference-nbr-page">
+    <choose>
+      <if type="paper-conference" match="any">
+        <group delimiter=", " font-style="normal">
+          <text variable="page" suffix="p."/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="entry-encyclopedia-nbr-page">
+    <choose>
+      <if type="entry-encyclopedia" match="any">
+        <group delimiter=", " font-style="normal">
+          <text variable="page" prefix=" : "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="journal-nbr-page">
+    <choose>
+      <if type="article-journal" match="any">
+        <group delimiter=", " font-style="normal">
+          <text variable="page"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="page-nbr">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis chapter entry-dictionary entry-encyclopedia article-journal article-newspaper article-magazine" match="any">
+        <group delimiter=" " font-style="normal">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis chapter entry-dictionary entry-encyclopedia" match="any">
+        <group font-style="normal">
+          <text term="volume" form="short" suffix=". "/>
+          <text variable="number-of-volumes" prefix=". " suffix="/"/>
+          <text variable="volume"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group prefix="[" suffix="]">
+              <number variable="edition" form="numeric"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix=" (dir.)"/>
+          </else>
+        </choose>
+        <text macro="issue" prefix=", "/>
+      </if>
+      <else-if type="article-journal article-magazine" match="any">
+        <group delimiter=", " font-style="normal">
+          <text macro="voljournal"/>
+          <date variable="issued">
+            <date-part name="day" suffix=" "/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if is-numeric="page">
+              <group>
+                <label variable="page" form="short"/>
+                <text variable="page" prefix=". "/>
+              </group>
+            </if>
+            <else>
+              <text variable="URL" text-decoration="underline"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="voljournal">
+    <group delimiter=",">
+      <text variable="volume" prefix="vol."/>
+      <text variable="issue" prefix=" n° "/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if is-numeric="issue">
+        <text term="issue" form="short" suffix=" "/>
+        <text variable="issue"/>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="encyclopediaTitle-cit">
+        <group>
+           <names variable="editor" prefix="dans " suffix=", dir.,">
+	    <name form="long" and="text" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+           </name>
+          <et-al font-style="italic"/>
+          </names>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix=" "/>
+        </group>
+  </macro>
+  <macro name="encyclopediaTitle-bib">
+        <group>
+           <names variable="editor" suffix=", dir.,">
+	    <name form="long" and="text" sort-separator=" " font-style="normal">
+            <name-part name="family" text-case="capitalize-first"/>
+           </name>
+          <et-al font-style="italic"/>
+          </names>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix=" "/>
+        </group>
+  </macro>
+  <macro name="collection">
+    <choose>
+      <if is-numeric="collection-number">
+        <group prefix=" (coll." suffix=")">
+          <text variable="collection-title" quotes="true" suffix="#160;"/>
+        </group>
+        <text variable="collection-number" prefix=", n˚ "/>
+      </if>
+      <else>
+        <group prefix=" (coll. " suffix=")">
+          <text variable="collection-title" quotes="true"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1">
+    <layout suffix="." delimiter=" ">
+      <choose>
+        <if position="ibid-with-locator">
+            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text variable="locator" prefix="p. "/>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="author-opcit"/>
+            <text term="cited" font-style="italic" suffix="."/>
+            <text variable="locator" prefix="p. "/>
+          </group>
+        </else-if>
+        <else>
+          <choose>
+            <if type="manuscript" match="any">
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="translator"/>
+                <text macro="yearpage-bib"/>
+                <text macro="pub-place"/>
+                <text macro="man-archive"/>
+                <text macro="edition"/>
+                <text macro="publisher"/>
+                <text macro="collection"/>
+                <text macro="page-nbr"/>
+              </group>
+            </if>
+            <else-if type="thesis" match="any">
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="yearpage-bib"/>
+                <text macro="page-nbr"/>
+              </group>
+            </else-if>
+            <else-if type="article-journal" match="any">
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="translator"/>
+                <text macro="pub-place"/>
+                <text macro="voljournal"/>
+              </group>
+                <text macro="yearpage" prefix=" (" suffix="), "/>
+                <text macro="page-nbr"/>
+            </else-if>
+            <else-if type="paper-conference" match="any">
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="translator"/>
+                <text macro="pub-place"/>
+                <text macro="publisher"/>
+                <text macro="yearpage-bib"/>
+                <text macro="volume"/>
+                <text macro="collection"/>
+                <text macro="page-nbr"/>
+              </group>
+            </else-if>
+            <else-if type="entry-encyclopedia" match="any">
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="encyclopediaTitle-cit"/>
+                <text macro="translator"/>
+                <text macro="pub-place"/>
+                <text macro="publisher"/>
+                <text macro="yearpage-bib"/>
+                <text macro="volume"/>
+                <text macro="page-nbr"/>
+              </group>
+            </else-if>
+        <else-if type="chapter" match="any">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text macro="title-cit"/>
+            <text macro="translator"/>
+            <text macro="volume"/>
+          </group>
+          <group delimiter=", ">
+            <text macro="pub-place" prefix=" "/>
+            <text macro="publisher"/>
+            <text macro="yearpage-bib"/>
+            <text macro="page-nbr"/>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper" match="any">
+            <text macro="author" suffix=", "/>
+            <text macro="title-cit"/>
+            <text macro="pub-place"/>
+            <text macro="yearpage" prefix=", "/>
+            <text macro="nbr-page"/>
+        </else-if>
+            <else>
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title-cit"/>
+                <text macro="translator"/>
+                <text macro="volume"/>
+                <text macro="pub-place"/>
+                <text macro="publisher"/>
+                <text macro="yearpage-bib"/>
+                <text macro="page-nbr"/>
+              </group>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1" entry-spacing="1" line-spacing="1">
+    <sort>
+      <key macro="author-bib" names-min="3" names-use-first="3"/>
+      <key variable="issued" sort="descending"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="manuscript" match="any">
+          <group delimiter=", ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+            <text macro="translator"/>
+            <text macro="yearpage-bib"/>
+            <text macro="pub-place"/>
+            <text macro="man-archive"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="collection"/>
+          </group>
+        </if>
+        <else-if type="thesis" match="any">
+          <group delimiter=". ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+            <text macro="yearpage-bib"/>
+            <text macro="nbr-page"/>
+          </group>
+        </else-if>
+        <else-if type="article-journal" match="any">
+          <group delimiter=". ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+          </group>
+          <group delimiter=", ">
+            <text macro="voljournal"/>
+          </group>
+            <text macro="yearpage" prefix=" (" suffix="): "/>
+            <text macro="journal-nbr-page"/>
+        </else-if>
+        <else-if type="chapter" match="any">
+          <group delimiter=". ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+            <text macro="translator"/>
+            <text macro="volume"/>
+          </group>
+          <group delimiter=", ">
+            <text macro="pub-place" prefix=" "/>
+            <text macro="publisher"/>
+            <text macro="yearpage-bib" suffix=": "/>
+          </group>
+            <text macro="chapter-nbr-page"/>
+            <text macro="collection"/>
+        </else-if>
+        <else-if type="paper-conference" match="any">
+          <group delimiter=", ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+            <text macro="translator"/>
+            <text macro="pub-place"/>
+            <text macro="publisher"/>
+            <text macro="yearpage-bib"/>
+            <text macro="volume"/>
+            <text macro="collection"/>
+            <text macro="conference-nbr-page"/>
+          </group>
+        </else-if>
+        <else-if type="entry-encyclopedia" match="any">
+          <group delimiter=". ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+            <text macro="encyclopediaTitle-bib"/>
+            <text macro="translator"/>
+            <text macro="pub-place" suffix=", "/>
+          </group>
+          <group delimiter=", ">
+            <text macro="publisher"/>
+            <text macro="yearpage-bib"/>
+          </group>
+            <text macro="volume"/>
+            <text macro="collection"/>
+            <text macro="entry-encyclopedia-nbr-page"/>
+        </else-if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song article-magazine chapter" match="any">
+            <text macro="author-bib" suffix=". "/>
+            <text macro="title-bib" suffix=". "/>
+            <text macro="volume" suffix=". "/>
+            <text macro="translator"/>
+          <group delimiter=", ">
+            <text macro="pub-place"/>
+            <text macro="publisher"/>
+            <text macro="yearpage-bib" suffix=". "/>
+          </group>
+            <text macro="nbr-page"/>
+            <text macro="collection" suffix="."/>
+        </else-if>
+        <else-if type="	post-weblog webpage" match="any">
+          <group delimiter=". ">
+            <text macro="author-bib"/>
+            <text macro="title-bib"/>
+          </group>
+            <text macro="yearpage-bib"/>
+            <text macro="nbr-page"/>
+        </else-if>
+        <else-if type="article-newspaper" match="any">
+            <text macro="author-bib" suffix=". "/>
+            <text macro="title-bib"/>
+            <text macro="pub-place"/>
+            <text macro="yearpage-bib"/>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-bib"/>
+            <text macro="document"/>
+            <text macro="yearpage"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is a new Zotero style for the « Département des sciences humaines de l'Université du Québec à Trois-Rivières (UQTR) ». We created this style to help UQTR history students learn to use Zotero while learning the department's citation style.